### PR TITLE
Created Markdown Template and Routed License Info

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,17 +6,42 @@ const fs = require("fs");
 // TODO: Create an array of questions for user input
 //const questions = [];
 
-function Project({ title, description, install, usage, contributing, test, license, username, email }) {
-    this.title = title;
-    this.description = description;
-    this.install = install;
-    this.usage = usage;
-    this.contributing = contributing;
-    this.test = test;
-    this.license = license;
-    this.username = username;
-    this.email = email;
-}
+const formatContent = ({ title, description, install, usage, contributing, test, license, username, email }, badge) =>
+`# ${title}
+${badge}
+
+## Description
+
+${description}
+
+## Installation
+
+${install}
+
+## Usage Instructions
+
+${usage}
+
+## How to Contribute
+
+${contributing}
+
+## Test Instructions
+
+${test}
+
+## License
+
+${license}
+
+## Questions
+
+Any questions or concerns regarding the project, you can contact me:
+
+Via my GitHub: https://github.com/${username}
+Or via my email: ${email}
+`
+
 
 function askUser() {
     inquirer
@@ -69,7 +94,12 @@ function askUser() {
             },
         ])
         .then((response) => {
-            const userInfo = new Project(response);
+            const badge = generateMarkdown.renderLicenseBadge(response.license);
+            const link = generateMarkdown.renderLicenseLink(response.license);
+            const licenseSection = generateMarkdown.renderLicenseSection(response.license, link);
+            response.license = licenseSection;
+            const markdown = formatContent(response, badge);
+            console.log(markdown);
         })
 }
 

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -1,14 +1,59 @@
 // TODO: Create a function that returns a license badge based on which license is passed in
 // If there is no license, return an empty string
-function renderLicenseBadge(license) {}
+function renderLicenseBadge(license) {
+  switch (license) {
+    case 'Apache 2.0':
+      var badge = "[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)";
+      return badge;
+    case 'MIT':
+      var badge = "[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)";
+      return badge;
+    case 'GNU GPLv3':
+      var badge = "[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)";
+      return badge;
+    case 'Mozilla Public License 2.0':
+      var badge = "[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)";
+      return badge;
+    case 'none':
+      var badge = "";
+      return badge;
+  }
+}
 
 // TODO: Create a function that returns the license link
 // If there is no license, return an empty string
-function renderLicenseLink(license) {}
+function renderLicenseLink(license) {
+  switch (license) {
+    case 'Apache 2.0':
+      var link = "https://www.apache.org/licenses/LICENSE-2.0.txt";
+      return link;
+    case 'MIT':
+      var link = "https://www.mit.edu/~amini/LICENSE.md";
+      return link;
+    case 'GNU GPLv3':
+      var link = "https://www.gnu.org/licenses/gpl-3.0.md";
+      return link;
+    case 'Mozilla Public License 2.0':
+      var link = "https://www.mozilla.org/en-US/MPL/2.0/";
+      return link;
+    case 'none':
+      var link = "";
+      return link;
+  }
+}
 
 // TODO: Create a function that returns the license section of README
 // If there is no license, return an empty string
-function renderLicenseSection(license) {}
+function renderLicenseSection(license, link) {
+  if (license !== "none") {
+    var licenseSection = `This project's license is ${license}.
+    For more information, go to ${link}`
+    return licenseSection;
+  } else {
+    var licenseSection = ""
+    return licenseSection;
+  }
+}
 
 // TODO: Create a function to generate markdown for README
 function generateMarkdown(data) {
@@ -17,4 +62,9 @@ function generateMarkdown(data) {
 `;
 }
 
-module.exports = generateMarkdown;
+module.exports = {
+  generateMarkdown,
+  renderLicenseBadge,
+  renderLicenseLink,
+  renderLicenseSection,
+};


### PR DESCRIPTION
- removed constructor for userInfo, as it ended up being redundant and unnecessary
- routed license choice to functions contained within generateMarkdown.js, using switch statements to return the corresponding links and badges
- created function within generateMarkdown.js to put together the name and link to the license in a readable format
- wrapped the README template in a function that passes all the needed variables